### PR TITLE
[WIP] correct degrees for self loop networks

### DIFF
--- a/pathpy/classes/network.py
+++ b/pathpy/classes/network.py
@@ -456,8 +456,8 @@ class Network:
         # update degrees and node weights
         if not self.directed:
             # update degree, in- and outweight
-            self.nodes[v]['degree'] = len(self.successors[v])
-            self.nodes[w]['degree'] = len(self.successors[w])
+            self.nodes[v]['degree'] += 1
+            self.nodes[w]['degree'] += 1
 
             S = [self.edges[(v,w)]['weight'] for w in self.successors[v]]
             if S:

--- a/tests/test_random_graphs.py
+++ b/tests/test_random_graphs.py
@@ -55,10 +55,6 @@ def test_is_graphic_sequence():
 
     for i in range(10):
         g = pp.algorithms.random_graphs.erdoes_renyi_gnp(n=100, p=0.03, self_loops=True)
-        # HACK: correct degrees for self_loops. Need to consistently define degrees of self-loops as two in pathpy!
-        for e in g.edges:
-            if e[0] == e[1]:
-                g.nodes[e[0]]['degree'] += 1
         assert pp.algorithms.random_graphs.is_graphic_sequence([x for x in g.degrees() if x > 0],
                                                                self_loops=True), \
             'Wrongly rejected degree sequence of randomly generated graph'


### PR DESCRIPTION
Self loop support for networks. 

The following hack is not required anymore:
```py
# HACK: correct degrees for self_loops. Need to consistently define degrees of self-loops as two in pathpy!
for e in g.edges:
    if e[0] == e[1]:
        g.nodes[e[0]]['degree'] += 1
```

- [x] correct degree during self loop creation
- [ ] correct degree during self loop removal
- [ ] add self loop case in `add_edge` test
- [ ] add self loop case in `remove_edge` test