### PR TITLE
fixed the url links in order to contribute to the uzhdag repository

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -15,7 +15,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at https://github.com/IngoScholtes/pathpy/issues.
+Report bugs at https://github.com/uzhdag/pathpy/issues.
 
 If you are reporting a bug, please include:
 
@@ -45,7 +45,7 @@ articles, and such.
 Submit Feedback
 ~~~~~~~~~~~~~~~
 
-The best way to send feedback is to file an issue at https://github.com/IngoScholtes/pathpy/issues.
+The best way to send feedback is to file an issue at https://github.com/uzhdag/pathpy/issues.
 
 If you are proposing a feature:
 
@@ -103,7 +103,7 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
 3. The pull request should work for Python 2.7, 3.4, 3.5 and 3.6, and for PyPy. Check
-   https://travis-ci.org/IngoScholtes/pathpy/pull_requests
+   https://travis-ci.org/uzhdag/pathpy/pull_requests
    and make sure that the tests pass for all supported Python versions.
 
 Tips


### PR DESCRIPTION
Hi, I fixed the url links in the contributing guide lines. Now the links are directed to the [uzhdag/pathpy](https://github.com/uzhdag/pathpy) repository. Please also update the https://travis-ci.org/ web-page and add the `uzhdag/pathpy` repository.