### PR TITLE
Update network.py [bug fix]

### DIFF
--- a/pathpy/classes/network.py
+++ b/pathpy/classes/network.py
@@ -824,7 +824,7 @@ def network_from_networkx(graph):
 
     net = Network(directed=directed)
     for node_id in graph.nodes:
-        net.add_node(str(node_id), **graph.node[node_id])
+        net.add_node(str(node_id), **graph.nodes[node_id])
 
     for edge in graph.edges:
         net.add_edge(str(edge[0]), str(edge[1]), **graph.edges[edge])


### PR DESCRIPTION
`nx.Graph` doesn't have a property `Graph.node`.  Calling `graph.node` raises the following error: `AttributeError: 'Graph' object has no attribute 'node'`. `graph.nodes` seems to work fine.